### PR TITLE
docs(setup): update LibreSign repository url

### DIFF
--- a/developer_manual/getting-started/development-environment/setup.rst
+++ b/developer_manual/getting-started/development-environment/setup.rst
@@ -58,7 +58,7 @@ Clone the LibreSign repository into this folder .
 
 .. code-block:: bash
 
-    git clone https://github.com/LibreCodeCoop/libresign.git
+    git clone https://github.com/LibreSign/libresign.git
     cd libresign
     git submodule update --init
 


### PR DESCRIPTION
This PR updates the documentation for the local development setup. Fixes the Clone the LibreSign repository step, updating the LibreSign repo url.