### PR TITLE
fix(ci): pin Sphinx to Python 3.11 compatible version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Sphinx==9.1.0
+Sphinx==9.0.4
 sphinx-rtd-theme==3.1.0
 sphinx-rtd-dark-mode==1.3.0
 sphinxcontrib-openapi==0.8.4


### PR DESCRIPTION
## Problem
The deploy workflow failed while installing dependencies because `Sphinx==9.1.0` requires Python >= 3.12, but the workflow runner uses Python 3.11.

## Root cause
Dependabot updated Sphinx to a version not compatible with the CI Python runtime.

## Fix
- Pin `Sphinx` to `9.0.4` in `requirements.txt`.
- This is the latest available 9.0.x release compatible with Python 3.11.

## Validation
- Reproduced failure from logs (`No matching distribution found for Sphinx==9.1.0`).
- Ran `python3 -m pip install -r requirements.txt` locally; install completed successfully.

## Notes
- Commit includes DCO sign-off.